### PR TITLE
fix(tinyauth): remove obsolete theme config

### DIFF
--- a/apps/base/tinyauth/tinyauth.config-map.yaml
+++ b/apps/base/tinyauth/tinyauth.config-map.yaml
@@ -18,9 +18,6 @@ data:
         APP_NAME: 타이니랙
 
     branding:
-      theme_mode: system
-      light_theme: light
-      dark_theme: black
       background_url: https://images.pexels.com/photos/5912576/pexels-photo-5912576.jpeg?auto=compress&cs=tinysrgb&w=1920
       title:
         ko: 타이니랙


### PR DESCRIPTION
## What changed

- remove `branding.theme_mode`, `branding.light_theme`, and `branding.dark_theme` from the Tinyrack TinyAuth ConfigMap

## Why

TinyAuth 0.18.0 removed these DaisyUI theme settings from its strict configuration schema. Flux updated the deployment image successfully, but the new pod exits with a Zod `unrecognized_keys` error and the rollout remains on the previous 0.17.0 pod.

## Impact

After Flux applies this change, the 0.18.0 pod can load the configuration and complete the rolling update. The existing 0.17.0 pod currently keeps the service available.

## Validation

- `kubectl kustomize ./apps/base/tinyauth`
- `kubectl kustomize ./apps/overlays/production`
- `git diff --check`
- confirmed the obsolete keys are absent from the rendered source