### PR TITLE
fix(tinyauth): restart after config update

### DIFF
--- a/apps/base/tinyauth/tinyauth.deployment.yaml
+++ b/apps/base/tinyauth/tinyauth.deployment.yaml
@@ -11,7 +11,7 @@ spec:
   template:
     metadata:
       annotations:
-        tinyauth.tinyrack.net/config-revision: branding-20260624-154518
+        tinyauth.tinyrack.net/config-revision: branding-20260729-234107
       labels:
         app: tinyauth
     spec:


### PR DESCRIPTION
## What changed

- update the TinyAuth pod-template `config-revision` annotation

## Why

The obsolete 0.18.0 branding keys were removed in #2, but the ConfigMap is mounted with `subPath`. Existing pods do not receive ConfigMap updates through a subPath mount, so changing the pod template is required to create a pod with the corrected configuration.

## Impact

Flux will perform a normal rolling update. The existing 0.17.0 pod remains available until the corrected 0.18.0 pod becomes Ready.

## Validation

- `kubectl kustomize ./apps/base/tinyauth`
- `kubectl kustomize ./apps/overlays/production`
- `git diff --check`