### PR TITLE
Deploy Coder relay

### DIFF
--- a/apps/base/coder-relay/coder-relay.deployment.yaml
+++ b/apps/base/coder-relay/coder-relay.deployment.yaml
@@ -1,0 +1,49 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: coder-relay
+  namespace: coder-relay-system
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: coder-relay
+  template:
+    metadata:
+      labels:
+        app: coder-relay
+    spec:
+      terminationGracePeriodSeconds: 35
+      containers:
+        - name: coder-relay
+          image: ghcr.io/tinyrack-net/coder-relay:v0.1.0 # {"$imagepolicy": "flux-system:coder-relay"}
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "128Mi"
+            limits:
+              cpu: "1"
+              memory: "512Mi"
+          livenessProbe:
+            httpGet:
+              path: /health/live
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health/ready
+              port: http
+            initialDelaySeconds: 2
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 3

--- a/apps/base/coder-relay/coder-relay.ingress.yaml
+++ b/apps/base/coder-relay/coder-relay.ingress.yaml
@@ -1,0 +1,38 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: coder-relay
+  namespace: coder-relay-system
+  annotations:
+    ingress.kubernetes.io/force-ssl-redirect: "true"
+spec:
+  ingressClassName: traefik
+  rules:
+    - host: relay.tinyrack.net
+      http:
+        paths:
+          - path: /v1/ws
+            pathType: Prefix
+            backend:
+              service:
+                name: coder-relay
+                port:
+                  name: http
+          - path: /health/live
+            pathType: Exact
+            backend:
+              service:
+                name: coder-relay
+                port:
+                  name: http
+          - path: /health/ready
+            pathType: Exact
+            backend:
+              service:
+                name: coder-relay
+                port:
+                  name: http
+  tls:
+    - hosts:
+        - relay.tinyrack.net
+      secretName: letsencrypt-cert

--- a/apps/base/coder-relay/coder-relay.namespace.yaml
+++ b/apps/base/coder-relay/coder-relay.namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: coder-relay-system

--- a/apps/base/coder-relay/coder-relay.service.yaml
+++ b/apps/base/coder-relay/coder-relay.service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: coder-relay
+  namespace: coder-relay-system
+spec:
+  selector:
+    app: coder-relay
+  ports:
+    - name: http
+      port: 80
+      targetPort: http

--- a/apps/base/coder-relay/kustomization.yaml
+++ b/apps/base/coder-relay/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - coder-relay.namespace.yaml
+  - coder-relay.deployment.yaml
+  - coder-relay.service.yaml
+  - coder-relay.ingress.yaml

--- a/apps/overlays/production/coder-relay.yaml
+++ b/apps/overlays/production/coder-relay.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: coder-relay-deployment
+  namespace: flux-system
+spec:
+  interval: 30m0s
+  path: ./apps/overlays/production/coder-relay/deployment
+  prune: true
+  retryInterval: 2m0s
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  timeout: 3m0s
+  wait: true
+  dependsOn:
+    - name: load-repositories

--- a/apps/overlays/production/coder-relay/deployment/kustomization.yaml
+++ b/apps/overlays/production/coder-relay/deployment/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../../../base/coder-relay

--- a/apps/overlays/production/kustomization.yaml
+++ b/apps/overlays/production/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - memos.yaml
   - discourse.yaml
   - tinyauth.yaml
+  - coder-relay.yaml

--- a/clusters/production/flux-system/image-automation.yaml
+++ b/clusters/production/flux-system/image-automation.yaml
@@ -51,3 +51,57 @@ spec:
   update:
     path: ./apps/base/tinyauth
     strategy: Setters
+---
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImageRepository
+metadata:
+  name: coder-relay
+  namespace: flux-system
+spec:
+  image: ghcr.io/tinyrack-net/coder-relay
+  interval: 5m
+---
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImagePolicy
+metadata:
+  name: coder-relay
+  namespace: flux-system
+spec:
+  imageRepositoryRef:
+    name: coder-relay
+  filterTags:
+    pattern: '^v(?P<version>[0-9]+\.[0-9]+\.[0-9]+)$'
+    extract: '$version'
+  policy:
+    semver:
+      range: '>=0.0.0 <1.0.0'
+---
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImageUpdateAutomation
+metadata:
+  name: coder-relay
+  namespace: flux-system
+spec:
+  interval: 10m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  git:
+    checkout:
+      ref:
+        branch: main
+    commit:
+      author:
+        name: flux-image-automation
+        email: flux-image-automation@users.noreply.github.com
+      messageTemplate: |
+        chore(images): update coder relay
+
+        {{ range .Changed.Changes -}}
+        - {{ .OldValue }} -> {{ .NewValue }}
+        {{ end -}}
+    push:
+      branch: main
+  update:
+    path: ./apps/base/coder-relay
+    strategy: Setters


### PR DESCRIPTION
## Summary
- deploy the single-replica Coder relay behind Traefik at relay.tinyrack.net
- expose only WebSocket and health paths while keeping metrics cluster-internal
- add dedicated Flux image scanning and update automation for immutable relay-v releases

## Validation
- kubectl kustomize apps/overlays/production/coder-relay/deployment
- kubectl --context tinyrack apply --server-side --dry-run=server -k apps/overlays/production
- kubectl --context tinyrack apply --server-side --dry-run=server -k clusters/production/flux-system
- anonymous GHCR manifest inspection for linux/amd64 and linux/arm64