### PR TITLE
Fix Coder relay hostname

### DIFF
--- a/apps/base/coder-relay/coder-relay.ingress.yaml
+++ b/apps/base/coder-relay/coder-relay.ingress.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   ingressClassName: traefik
   rules:
-    - host: relay.tinyrack.net
+    - host: relay.coder.tinyrack.net
       http:
         paths:
           - path: /v1/ws
@@ -34,5 +34,5 @@ spec:
                   name: http
   tls:
     - hosts:
-        - relay.tinyrack.net
+        - relay.coder.tinyrack.net
       secretName: letsencrypt-cert


### PR DESCRIPTION
## What changed

- changed the Coder relay Ingress and TLS host from `relay.tinyrack.net` to `relay.coder.tinyrack.net`

## Why

The production relay belongs under the Coder subdomain.

## Validation

- rendered `apps/overlays/production/coder-relay/deployment`
- verified the old hostname is absent from the GitOps manifests
- passed a server-side dry-run against the `tinyrack` context with the GitOps-owned field conflicts explicitly forced in dry-run mode