### PR TITLE
Add Coder wildcard certificate

### DIFF
--- a/infrastructure/base/cert-manager/configs/letsencrypt-certification.certificate.yaml
+++ b/infrastructure/base/cert-manager/configs/letsencrypt-certification.certificate.yaml
@@ -17,3 +17,4 @@ spec:
   dnsNames:
     - "tinyrack.net"
     - "*.tinyrack.net"
+    - "*.coder.tinyrack.net"


### PR DESCRIPTION
## What changed

- added `*.coder.tinyrack.net` to the shared Let's Encrypt certificate SANs

## Why

`relay.coder.tinyrack.net` is a two-level subdomain and is not covered by the existing `*.tinyrack.net` wildcard. Cloudflared therefore rejected Traefik's origin certificate with an x509 hostname mismatch.

## Impact

Cloudflared can keep strict TLS verification enabled for Coder subdomains.

## Validation

- rendered `infrastructure/base/cert-manager/configs`
- confirmed the rendered Certificate includes `*.coder.tinyrack.net`
- passed server-side dry-run against the `tinyrack` context