### PR TITLE
fix(relay): track the Tinest relay image

### DIFF
--- a/apps/base/coder-relay/coder-relay.deployment.yaml
+++ b/apps/base/coder-relay/coder-relay.deployment.yaml
@@ -18,7 +18,7 @@ spec:
       terminationGracePeriodSeconds: 35
       containers:
         - name: coder-relay
-          image: ghcr.io/tinyrack-net/coder-relay:v0.2.0 # {"$imagepolicy": "flux-system:coder-relay"}
+          image: ghcr.io/tinyrack-net/tinest-relay:v0.5.2 # {"$imagepolicy": "flux-system:coder-relay"}
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/clusters/production/flux-system/image-automation.yaml
+++ b/clusters/production/flux-system/image-automation.yaml
@@ -58,7 +58,7 @@ metadata:
   name: coder-relay
   namespace: flux-system
 spec:
-  image: ghcr.io/tinyrack-net/coder-relay
+  image: ghcr.io/tinyrack-net/tinest-relay
   interval: 5m
 ---
 apiVersion: image.toolkit.fluxcd.io/v1


### PR DESCRIPTION
Deploy tinest-relay v0.5.2 while retaining the existing coder-relay Kubernetes resources, and point Flux image discovery at the current Tinest relay package. Verified both production Kustomize trees and git diff check.