### PR TITLE
chore(tinyauth): stop writes for migration

### DIFF
--- a/apps/base/tinyauth/tinyauth.deployment.yaml
+++ b/apps/base/tinyauth/tinyauth.deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: tinyauth
   namespace: tinyauth-system
 spec:
-  replicas: 1
+  replicas: 0
   selector:
     matchLabels:
       app: tinyauth


### PR DESCRIPTION
## Summary
- scale TinyAuth to zero before the final migration backup

## Validation
- `kubectl kustomize ./apps/base/tinyauth`
- `kubectl kustomize ./apps/overlays/production`