### PR TITLE
feat(issuary): enable database recovery

### DIFF
--- a/apps/overlays/production/kustomization.yaml
+++ b/apps/overlays/production/kustomization.yaml
@@ -5,4 +5,5 @@ resources:
   - memos.yaml
   - discourse.yaml
   - tinyauth.yaml
+  - issuary.yaml
   - coder-relay.yaml


### PR DESCRIPTION
## Summary
- enable the separate Issuary Kustomization after the final TinyAuth backup
- keep Issuary scaled to zero and without ingress during recovery

## Recovery baseline
- final backup: `tinyauth-database-cluster-20260825021912`
- users: 4; OAuth clients: 1; JWT keys: 3; migrations: 8
- application connections at cutoff: 0