### PR TITLE
chore(tinyauth): remove legacy ingress

### DIFF
--- a/apps/base/tinyauth/kustomization.yaml
+++ b/apps/base/tinyauth/kustomization.yaml
@@ -9,4 +9,3 @@ resources:
   - tinyauth.config-map.yaml
   - tinyauth.deployment.yaml
   - tinyauth.service.yaml
-  - tinyauth.ingress.yaml


### PR DESCRIPTION
## Summary
- remove the legacy TinyAuth ingress before transferring `auth.tinyrack.net` to Issuary

Issuary internal health and OIDC discovery have already been verified.