### PR TITLE
feat(issuary): enable production ingress

### DIFF
--- a/apps/base/issuary/kustomization.yaml
+++ b/apps/base/issuary/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
   - issuary.config-map.yaml
   - issuary.deployment.yaml
   - issuary.service.yaml
+  - issuary.ingress.yaml


### PR DESCRIPTION
## Summary
- attach `auth.tinyrack.net` to the verified Issuary service

The legacy ingress has been removed and the host is currently unclaimed.