### PR TITLE
chore(tinyauth): prune legacy production stack

### DIFF
--- a/apps/overlays/production/kustomization.yaml
+++ b/apps/overlays/production/kustomization.yaml
@@ -4,6 +4,5 @@ resources:
   - repositories.yaml
   - memos.yaml
   - discourse.yaml
-  - tinyauth.yaml
   - issuary.yaml
   - coder-relay.yaml


### PR DESCRIPTION
## Summary
- remove the stopped legacy TinyAuth Kustomization from production
- allow Flux to prune `tinyauth-system` after successful Issuary cutover and backup

## Safety evidence
- Issuary deployment: 1/1
- external health: 200
- Issuary backup `issuary-database-cluster-20260825023132`: completed
- Issuary WAL archiving: OK