### PR TITLE
chore(platform): update utility charts

### DIFF
--- a/apps/base/repositories/redis.yaml
+++ b/apps/base/repositories/redis.yaml
@@ -7,4 +7,4 @@ spec:
   interval: 30m0s
   url: oci://registry-1.docker.io/bitnamicharts/redis
   ref:
-   tag: "22.0.7"
+    tag: "28.0.10"

--- a/infrastructure/base/external-secrets/external-secrets.helm-release.yaml
+++ b/infrastructure/base/external-secrets/external-secrets.helm-release.yaml
@@ -7,7 +7,7 @@ spec:
   chart:
     spec:
       chart: external-secrets
-      version: "0.19.2"
+      version: "2.9.0"
       sourceRef:
         kind: HelmRepository
         name: external-secrets-repository

--- a/infrastructure/base/ot-redis-operator/ot-redis-operator.helm-release.yaml
+++ b/infrastructure/base/ot-redis-operator/ot-redis-operator.helm-release.yaml
@@ -7,7 +7,7 @@ spec:
   chart:
     spec:
       chart: redis-operator
-      version: "0.25.0"
+      version: "0.26.1"
       sourceRef:
         kind: HelmRepository
         name: ot-container-kit-repository

--- a/infrastructure/base/reflector/reflector.helm-release.yaml
+++ b/infrastructure/base/reflector/reflector.helm-release.yaml
@@ -7,7 +7,7 @@ spec:
   chart:
     spec:
       chart: reflector
-      version: '10.0.61'
+      version: '10.0.65'
       sourceRef:
         kind: HelmRepository
         name: reflector

--- a/infrastructure/base/sealed-secrets/sealed-secrets.helm-release.yaml
+++ b/infrastructure/base/sealed-secrets/sealed-secrets.helm-release.yaml
@@ -7,7 +7,7 @@ spec:
   chart:
     spec:
       chart: sealed-secrets
-      version: '2.19.1'
+      version: '2.19.3'
       sourceRef:
         kind: HelmRepository
         name: sealed-secrets-repository


### PR DESCRIPTION
## Summary
- update Redis Operator to chart 0.26.1
- update Reflector to 10.0.65 and Sealed Secrets to chart 2.19.3
- refresh inactive External Secrets and Redis OCI chart pins without enabling them

## Validation
- rendered all updated Helm charts
- rendered production infrastructure and apps overlays
- server-side dry-run of reconciled resources