### PR TITLE
chore(tailscale): update operator to 1.102.3

### DIFF
--- a/infrastructure/base/tailscale/install/tailscale.helm-release.yaml
+++ b/infrastructure/base/tailscale/install/tailscale.helm-release.yaml
@@ -12,7 +12,7 @@ spec:
         kind: HelmRepository
         name: tailscale
         namespace: flux-system
-      version: "1.98.9"
+      version: "1.102.3"
   values:
     apiServerProxyConfig:
       mode: "noauth"


### PR DESCRIPTION
## Summary
- update the Tailscale operator chart to 1.102.3

## Validation
- rendered the updated chart with the current API proxy settings
- rendered the production infrastructure overlay
- server-side dry-run of the HelmRelease