### PR TITLE
chore(network): update Traefik and cloudflared

### DIFF
--- a/infrastructure/base/cloudflared/cloudflared.deployment.yaml
+++ b/infrastructure/base/cloudflared/cloudflared.deployment.yaml
@@ -34,7 +34,7 @@ spec:
           args:
             - --token
             - "$(CLOUDFLARED_TOKEN)"
-          image: cloudflare/cloudflared:2026.7.3
+          image: cloudflare/cloudflared:2026.8.2
           name: cloudflared
           env:
             - name: CLOUDFLARED_TOKEN

--- a/infrastructure/base/traefik/traefik.helm-release.yaml
+++ b/infrastructure/base/traefik/traefik.helm-release.yaml
@@ -7,7 +7,7 @@ spec:
   chart:
     spec:
       chart: traefik
-      version: '41.1.0'
+      version: '41.3.0'
       sourceRef:
         kind: HelmRepository
         name: traefik-repository


### PR DESCRIPTION
## Summary
- update Traefik chart to 41.3.0 (Traefik 3.7.11)
- update cloudflared to 2026.8.2

## Validation
- render updated Traefik chart with production values
- render production infrastructure overlay
- server-side dry-run of both resources