### PR TITLE
chore(longhorn): update to 1.12.1

### DIFF
--- a/infrastructure/base/longhorn/install/longhorn.helm-release.yaml
+++ b/infrastructure/base/longhorn/install/longhorn.helm-release.yaml
@@ -7,7 +7,7 @@ spec:
   chart:
     spec:
       chart: longhorn
-      version: "1.12.0"
+      version: "1.12.1"
       sourceRef:
         kind: HelmRepository
         name: longhorn
@@ -23,7 +23,7 @@ spec:
     defaultSettings:
       storageMinimalAvailablePercentage: 5
       defaultReplicaCount: 1
-      concurrentAutomaticEngineUpgradePerNodeLimit: 0
+      concurrentAutomaticEngineUpgradePerNodeLimit: 1
     defaultBackupStore:
       backupTarget: s3://tinyrack-prod@hetzner/longhorn
       backupTargetCredentialSecret: tinyrack-s3-secret


### PR DESCRIPTION
## Summary
- update Longhorn chart to 1.12.1
- allow one automatic volume engine upgrade at a time during maintenance

## Safety
- pre-upgrade SystemBackup pre-upgrade-20260825 is Ready with volume backups

## Validation
- render Longhorn 1.12.1 with production values
- render production infrastructure overlay
- server-side dry-run of the HelmRelease