### PR TITLE
chore(longhorn): retry remaining engine upgrades

### DIFF
--- a/infrastructure/base/longhorn/install/longhorn.helm-release.yaml
+++ b/infrastructure/base/longhorn/install/longhorn.helm-release.yaml
@@ -23,7 +23,7 @@ spec:
     defaultSettings:
       storageMinimalAvailablePercentage: 5
       defaultReplicaCount: 1
-      concurrentAutomaticEngineUpgradePerNodeLimit: 1
+      concurrentAutomaticEngineUpgradePerNodeLimit: 3
     defaultBackupStore:
       backupTarget: s3://tinyrack-prod@hetzner/longhorn
       backupTargetCredentialSecret: tinyrack-s3-secret


### PR DESCRIPTION
## Summary
- temporarily raise the automatic engine upgrade limit to the Longhorn-recommended value of 3
- retry the two volumes left on engine v1.12.0 after transient instance-manager startup failures

All volumes are currently attached and healthy. This setting will return to 0 after every engine reaches v1.12.1.