### PR TITLE
fix(longhorn): disable automatic engine upgrades

### DIFF
--- a/infrastructure/base/longhorn/install/longhorn.helm-release.yaml
+++ b/infrastructure/base/longhorn/install/longhorn.helm-release.yaml
@@ -23,7 +23,7 @@ spec:
     defaultSettings:
       storageMinimalAvailablePercentage: 5
       defaultReplicaCount: 1
-      concurrentAutomaticEngineUpgradePerNodeLimit: 3
+      concurrentAutomaticEngineUpgradePerNodeLimit: 0
     defaultBackupStore:
       backupTarget: s3://tinyrack-prod@hetzner/longhorn
       backupTargetCredentialSecret: tinyrack-s3-secret


### PR DESCRIPTION
## Summary
- disable concurrent automatic engine upgrades after strict-local volumes failed online upgrade
- keep remaining engine upgrades for controlled offline maintenance windows

## Validation
- kubectl kustomize infrastructure/overlays/production
- kubectl apply --dry-run=server