### PR TITLE
chore(memos): pause writes for PostgreSQL upgrade

### DIFF
--- a/apps/base/memos/memos.deployment.yaml
+++ b/apps/base/memos/memos.deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: memos
   namespace: memos-system
 spec:
-  replicas: 2
+  replicas: 0
   selector:
     matchLabels:
       app: memos


### PR DESCRIPTION
## Summary
- scale Memos to zero before the PostgreSQL 18 maintenance window

## Validation
- kubectl kustomize apps/overlays/production
- kubectl apply --dry-run=server