### PR TITLE
feat(memos): upgrade PostgreSQL to 18

### DIFF
--- a/apps/base/memos/memos.database.yaml
+++ b/apps/base/memos/memos.database.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   retentionPolicy: 30d
   configuration:
+    serverName: memos-database-cluster-pg18
     destinationPath: s3://tinyrack-prod/apps/memos/database
     endpointURL: https://fsn1.your-objectstorage.com
     s3Credentials:
@@ -30,7 +31,7 @@ metadata:
     cnpg.io/skipEmptyWalArchiveCheck: "enabled"
 spec:
   instances: 1
-  imageName: ghcr.io/cloudnative-pg/postgresql:17-bookworm
+  imageName: ghcr.io/cloudnative-pg/postgresql:18-standard-bookworm
   storage:
     pvcTemplate:
       accessModes:


### PR DESCRIPTION
## Summary
- upgrade Memos from PostgreSQL 17 to PostgreSQL 18.6 via the current standard Bookworm image
- move PostgreSQL 18 WAL and base backups to a new Barman server name

## Safety
- Memos writes are paused
- pre-upgrade backup `memos-pre-pg18-20260825` completed
- restore rehearsal, pg_upgrade, exact row-count fingerprint, write/read, and ANALYZE passed

## Validation
- kubectl kustomize apps/overlays/production
- kubectl apply --dry-run=server