### PR TITLE
chore(issuary): hold production rollout

### DIFF
--- a/clusters/production/flux-system/image-automation.yaml
+++ b/clusters/production/flux-system/image-automation.yaml
@@ -28,6 +28,7 @@ metadata:
   name: issuary
   namespace: flux-system
 spec:
+  suspend: true
   interval: 10m
   sourceRef:
     kind: GitRepository


### PR DESCRIPTION
Temporarily suspend only the Issuary image automation so v0.21.1 can be validated on homelab first. The workload remains pinned at 0.21.0 until this is reverted after canary validation.