### PR TITLE
chore(issuary): stage 0.22 rollout

### DIFF
--- a/clusters/production/flux-system/image-automation.yaml
+++ b/clusters/production/flux-system/image-automation.yaml
@@ -28,6 +28,7 @@ metadata:
   name: issuary
   namespace: flux-system
 spec:
+  suspend: true
   interval: 10m
   sourceRef:
     kind: GitRepository


### PR DESCRIPTION
Temporarily suspends Issuary image automation so the 0.22 credential-retirement release can be validated on homelab before production rollout. The Issuary workload remains running.