### PR TITLE
feat(issuary): retire legacy v1 credentials

### DIFF
--- a/apps/base/issuary/issuary.config-map.yaml
+++ b/apps/base/issuary/issuary.config-map.yaml
@@ -43,6 +43,7 @@ data:
     security:
       session_secret: ${ISSUARY_SESSION_SECRET}
       hash_secret: ${ISSUARY_HASH_SECRET}
+      retire_legacy_v1_credentials: true
 
     email:
       transport: smtp

--- a/apps/base/issuary/issuary.deployment.yaml
+++ b/apps/base/issuary/issuary.deployment.yaml
@@ -11,13 +11,13 @@ spec:
   template:
     metadata:
       annotations:
-        issuary.tinyrack.net/config-revision: migration-20260825
+        issuary.tinyrack.net/config-revision: retire-v1-20260825
       labels:
         app: issuary
     spec:
       containers:
         - name: issuary
-          image: ghcr.io/tinyrack-net/issuary:0.21.1 # {"$imagepolicy": "flux-system:issuary"}
+          image: ghcr.io/tinyrack-net/issuary:0.22.0 # {"$imagepolicy": "flux-system:issuary"}
           imagePullPolicy: IfNotPresent
           command:
             - node

--- a/clusters/production/flux-system/image-automation.yaml
+++ b/clusters/production/flux-system/image-automation.yaml
@@ -28,7 +28,6 @@ metadata:
   name: issuary
   namespace: flux-system
 spec:
-  suspend: true
   interval: 10m
   sourceRef:
     kind: GitRepository


### PR DESCRIPTION
## Summary
- deploy Issuary 0.22.0
- enable one-way retirement of legacy v1 credentials
- restart the deployment for the config change
- resume image automation after the guarded rollout

## Safety
- completed CNPG plugin backup `issuary-pre-v1-retirement-plugin-20260825`
- validated app and infrastructure kustomizations
- homelab rollout completed successfully first

## Expected migration
- retire one v1 password and mark its user as password-reset-required
- preserve the existing passkey
- require passkey or emailed reset-token verification before choosing a new password
- destroy the restricted reset session after password creation; a fresh password login (and TOTP where configured) is still required