### PR TITLE
refactor(relay): remove coder naming

### DIFF
--- a/apps/base/coder-relay/kustomization.yaml
+++ b/apps/base/coder-relay/kustomization.yaml
@@ -1,7 +1,0 @@
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-resources:
-  - coder-relay.namespace.yaml
-  - coder-relay.deployment.yaml
-  - coder-relay.service.yaml
-  - coder-relay.ingress.yaml

--- a/apps/base/tinest-relay/kustomization.yaml
+++ b/apps/base/tinest-relay/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - tinest-relay.namespace.yaml
+  - tinest-relay.deployment.yaml
+  - tinest-relay.service.yaml
+  - tinest-relay.ingress.yaml

--- a/apps/base/tinest-relay/tinest-relay.deployment.yaml
+++ b/apps/base/tinest-relay/tinest-relay.deployment.yaml
@@ -1,24 +1,24 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: coder-relay
-  namespace: coder-relay-system
+  name: tinest-relay
+  namespace: tinest-relay-system
 spec:
   replicas: 1
   strategy:
     type: Recreate
   selector:
     matchLabels:
-      app: coder-relay
+      app: tinest-relay
   template:
     metadata:
       labels:
-        app: coder-relay
+        app: tinest-relay
     spec:
       terminationGracePeriodSeconds: 35
       containers:
-        - name: coder-relay
-          image: ghcr.io/tinyrack-net/tinest-relay:v0.6.0 # {"$imagepolicy": "flux-system:coder-relay"}
+        - name: tinest-relay
+          image: ghcr.io/tinyrack-net/tinest-relay:v0.6.0 # {"$imagepolicy": "flux-system:tinest-relay"}
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/apps/base/tinest-relay/tinest-relay.ingress.yaml
+++ b/apps/base/tinest-relay/tinest-relay.ingress.yaml
@@ -1,8 +1,8 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: coder-relay
-  namespace: coder-relay-system
+  name: tinest-relay
+  namespace: tinest-relay-system
   annotations:
     ingress.kubernetes.io/force-ssl-redirect: "true"
 spec:
@@ -15,21 +15,21 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: coder-relay
+                name: tinest-relay
                 port:
                   name: http
           - path: /health/live
             pathType: Exact
             backend:
               service:
-                name: coder-relay
+                name: tinest-relay
                 port:
                   name: http
           - path: /health/ready
             pathType: Exact
             backend:
               service:
-                name: coder-relay
+                name: tinest-relay
                 port:
                   name: http
   tls:

--- a/apps/base/tinest-relay/tinest-relay.namespace.yaml
+++ b/apps/base/tinest-relay/tinest-relay.namespace.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: coder-relay-system
+  name: tinest-relay-system

--- a/apps/base/tinest-relay/tinest-relay.service.yaml
+++ b/apps/base/tinest-relay/tinest-relay.service.yaml
@@ -1,11 +1,11 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: coder-relay
-  namespace: coder-relay-system
+  name: tinest-relay
+  namespace: tinest-relay-system
 spec:
   selector:
-    app: coder-relay
+    app: tinest-relay
   ports:
     - name: http
       port: 80

--- a/apps/overlays/production/kustomization.yaml
+++ b/apps/overlays/production/kustomization.yaml
@@ -5,4 +5,4 @@ resources:
   - memos.yaml
   - discourse.yaml
   - issuary.yaml
-  - coder-relay.yaml
+  - tinest-relay.yaml

--- a/apps/overlays/production/tinest-relay.yaml
+++ b/apps/overlays/production/tinest-relay.yaml
@@ -1,11 +1,11 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: coder-relay-deployment
+  name: tinest-relay-deployment
   namespace: flux-system
 spec:
   interval: 30m0s
-  path: ./apps/overlays/production/coder-relay/deployment
+  path: ./apps/overlays/production/tinest-relay/deployment
   prune: true
   retryInterval: 2m0s
   sourceRef:

--- a/apps/overlays/production/tinest-relay/deployment/kustomization.yaml
+++ b/apps/overlays/production/tinest-relay/deployment/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ../../../../base/coder-relay
+  - ../../../../base/tinest-relay

--- a/clusters/production/flux-system/image-automation.yaml
+++ b/clusters/production/flux-system/image-automation.yaml
@@ -55,7 +55,7 @@ spec:
 apiVersion: image.toolkit.fluxcd.io/v1
 kind: ImageRepository
 metadata:
-  name: coder-relay
+  name: tinest-relay
   namespace: flux-system
 spec:
   image: ghcr.io/tinyrack-net/tinest-relay
@@ -64,11 +64,11 @@ spec:
 apiVersion: image.toolkit.fluxcd.io/v1
 kind: ImagePolicy
 metadata:
-  name: coder-relay
+  name: tinest-relay
   namespace: flux-system
 spec:
   imageRepositoryRef:
-    name: coder-relay
+    name: tinest-relay
   filterTags:
     pattern: '^v(?P<version>[0-9]+\.[0-9]+\.[0-9]+)$'
     extract: '$version'
@@ -79,7 +79,7 @@ spec:
 apiVersion: image.toolkit.fluxcd.io/v1
 kind: ImageUpdateAutomation
 metadata:
-  name: coder-relay
+  name: tinest-relay
   namespace: flux-system
 spec:
   interval: 10m
@@ -95,7 +95,7 @@ spec:
         name: flux-image-automation
         email: flux-image-automation@users.noreply.github.com
       messageTemplate: |
-        chore(images): update coder relay
+        chore(images): update Tinest relay
 
         {{ range .Changed.Changes -}}
         - {{ .OldValue }} -> {{ .NewValue }}
@@ -103,5 +103,5 @@ spec:
     push:
       branch: main
   update:
-    path: ./apps/base/coder-relay
+    path: ./apps/base/tinest-relay
     strategy: Setters

--- a/infrastructure/base/cert-manager/configs/letsencrypt-certification.certificate.yaml
+++ b/infrastructure/base/cert-manager/configs/letsencrypt-certification.certificate.yaml
@@ -17,5 +17,4 @@ spec:
   dnsNames:
     - "tinyrack.net"
     - "*.tinyrack.net"
-    - "*.coder.tinyrack.net"
     - "*.tinest.tinyrack.net"


### PR DESCRIPTION
## Summary
- rename relay Kubernetes and Flux resources from coder to tinest
- update image automation references and paths
- remove the legacy coder wildcard certificate SAN

## Validation
- rendered all affected Kustomize trees
- verified repository and rendered output contain no coder references
- passed kubectl client-side dry-run for affected resources