### PR TITLE
feat: deploy Issuary 0.23.0

### DIFF
--- a/apps/base/issuary/issuary.config-map.yaml
+++ b/apps/base/issuary/issuary.config-map.yaml
@@ -43,7 +43,6 @@ data:
     security:
       session_secret: ${ISSUARY_SESSION_SECRET}
       hash_secret: ${ISSUARY_HASH_SECRET}
-      retire_legacy_v1_credentials: true
 
     email:
       transport: smtp

--- a/apps/base/issuary/issuary.deployment.yaml
+++ b/apps/base/issuary/issuary.deployment.yaml
@@ -11,7 +11,7 @@ spec:
   template:
     metadata:
       annotations:
-        issuary.tinyrack.net/config-revision: retire-v1-20260825
+        issuary.tinyrack.net/config-revision: remove-v1-20260825
       labels:
         app: issuary
     spec:


### PR DESCRIPTION
## Summary
- deploy Issuary 0.23.0
- remove the retired legacy v1 credential configuration
- trigger a controlled rollout

## Validation
- `kubectl kustomize ./apps/base/issuary`
- `kubectl kustomize ./apps/overlays/production`
- `kubectl kustomize ./infrastructure/overlays/production`

Merge only after the 0.23.0 multi-architecture image is published.