### PR TITLE
fix(issuary): remove retired branding options

### DIFF
--- a/apps/base/issuary/issuary.config-map.yaml
+++ b/apps/base/issuary/issuary.config-map.yaml
@@ -18,15 +18,10 @@ data:
         APP_NAME: 타이니랙
 
     branding:
-      background_url: https://images.pexels.com/photos/5912576/pexels-photo-5912576.jpeg?auto=compress&cs=tinysrgb&w=1920
       title:
         ko: 타이니랙
         en: Tinyrack
         ja: タイニーラック
-      subtitle:
-        ko: 타이니랙에 오신 것을 환영합니다
-        en: Welcome to Tinyrack
-        ja: タイニーラックへようこそ
 
     logging:
       level: info

--- a/apps/base/issuary/issuary.deployment.yaml
+++ b/apps/base/issuary/issuary.deployment.yaml
@@ -11,7 +11,7 @@ spec:
   template:
     metadata:
       annotations:
-        issuary.tinyrack.net/config-revision: remove-v1-20260825
+        issuary.tinyrack.net/config-revision: branding-v2-20260827
       labels:
         app: issuary
     spec:


### PR DESCRIPTION
## Summary
- remove Issuary branding options retired in v0.24.0
- bump the pod template config revision so Flux performs a clean rollout

## Verification
- `kubectl kustomize ./apps/base/issuary`
- `kubectl kustomize ./apps/overlays/production`
- rendered config contains no `background_url` or `subtitle`
- `git diff --check`